### PR TITLE
add dialog interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(menu SHARED
     mpv/ta/ta_talloc.c
     mpv/ta/ta_utils.c
 
+    src/dialog.c
     src/menu.c
     src/plugin.c
 )

--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ MBTN_RIGHT script-message-to menu show
 
 #### `user-data/menu/items`
 
+> [!TIP]
+> To reduce update frequency, it's recommended to update this property in [mp.register_idle(fn)](https://mpv.io/manual/master/#lua-scripting-mp-register-idle(fn)).
+
 ```
 MPV_FORMAT_NODE_ARRAY
   MPV_FORMAT_NODE_MAP (menu item)
@@ -98,23 +101,93 @@ MPV_FORMAT_NODE_ARRAY
 
 The menu data of the C plugin is stored in this property, updating it will trigger an update of the menu UI.
 
-To reduce update frequency, it's recommended to update this property in [mp.register_idle(fn)](https://mpv.io/manual/master/#lua-scripting-mp-register-idle(fn)).
+> [!NOTE]
+> Be aware that `dyn_menu.lua` is conflict with other scripts that also update the `user-data/menu/items` property,
+> you may use the messages below if you only want to update part of the menu.
 
-Be aware that `dyn_menu.lua` is conflict with other scripts that also update the `user-data/menu/items` property,
-you may use the messages below if you only want to update part of the menu.
+#### `user-data/menu/dialog/filters`
+
+```
+MPV_FORMAT_NODE_ARRAY
+  MPV_FORMAT_NODE_MAP
+    "name"            MPV_FORMAT_STRING
+    "spec"            MPV_FORMAT_STRING
+```
+
+Custom file type filters used for open dialog, the first one will be selected by default.
+
+Example:
+
+```lua
+local file_types = {
+    { name = 'All Files (*.*)', spec = '*.*' },
+    { name = 'Video Files',     spec = '*mp4;*.mkv' },
+    { name = 'Audio Files',     spec = '*.mp3;*.m4a' },
+    { name = 'Subtitle Files',  spec = '*.srt;*.ass' },
+    { name = 'Playlist Files',  spec = '*.m3u;*.m3u8' },
+}
+```
+
+#### `user-data/menu/dialog/default-path`
+
+Default path for open and save dialog.
+
+#### `user-data/menu/dialog/default-name`
+
+Default file name for save dialog.
 
 ### Messages
 
 > [!TIP]
 > Want a usage example? Check [Scripting example](https://github.com/tsl0922/mpv-menu-plugin/wiki/Scripting-example) in the wiki.
 
-#### `menu-ready`
+#### Script Messages supported by `menu.dll`:
+
+##### `clipboard/get <src>`
+
+Retrieves data from the clipboard (text only).
+
+The result is replied via: `srcript-message-to <src> clipboard-get-reply <text>`.
+
+##### `clipboard/set <text>`
+
+Places data on the clipboard (text only).
+
+##### `dialog/open <src>`
+
+Show an open dialog.
+
+The result is replied via: `srcript-message-to <src> dialog-open-reply <path>`.
+
+##### `dialog/open-multi <src>`
+
+Show an open dialog that can select multiple files.
+
+The result is replied via: `srcript-message-to <src> dialog-open-multi-reply <path1> <path2> ...`.
+
+##### `dialog/open-folder <src>`
+
+Show an open dialog that can select folder only.
+
+The result is replied via: `srcript-message-to <src> dialog-open-folder-reply <path>`.
+
+##### `dialog/save <src>`
+
+Show a save dialog.
+
+The result is replied via: `srcript-message-to <src> dialog-save-reply <path>`.
+
+#### Script Messages supported by `dyn_menu.lua`:
+
+##### `menu-ready`
 
 Broadcasted when `dyn_menu.lua` has initialized itself.
 
-#### `get <keyword> <src>`
+##### `get <keyword> <src>`
 
-Get the menu item structure of `keyword`, and send a json reply to `src`.
+Get the menu item structure of `keyword`.
+
+The result is replied via: `srcript-message-to <src> menu-get-reply <json>`.
 
 ```json
 {
@@ -127,11 +200,9 @@ Get the menu item structure of `keyword`, and send a json reply to `src`.
 }
 ```
 
-The reply is sent via `srcript-message-to <src> menu-get-reply <json>`.
-
 If `keyword` is not found, the result json will contain an additional `error` field, and no `item` field.
 
-#### `update <keyword> <json>`
+##### `update <keyword> <json>`
 
 Update the menu item structure of `keyword` with `json`.
 

--- a/src/dialog.c
+++ b/src/dialog.c
@@ -1,0 +1,228 @@
+#include <windows.h>
+#include <shobjidl.h>
+#include <mpv/client.h>
+#include "mpv_talloc.h"
+#include "dialog.h"
+
+#define DIALOG_FILTER_PROP "user-data/menu/dialog/filters"
+#define DIALOG_DEF_PATH_PROP "user-data/menu/dialog/default-path"
+#define DIALOG_DEF_NAME_PROP "user-data/menu/dialog/default-name"
+
+// add filters to dialog from user property, default to first one
+static void add_filters(mpv_handle *mpv, IFileDialog *pfd) {
+    mpv_node node = {0};
+    if (mpv_get_property(mpv, DIALOG_FILTER_PROP, MPV_FORMAT_NODE, &node) < 0)
+        return;
+    if (node.format != MPV_FORMAT_NODE_ARRAY) goto done;
+
+    void *tmp = talloc_new(NULL);
+    mpv_node_list *list = node.u.list;
+    COMDLG_FILTERSPEC *specs = talloc_array(tmp, COMDLG_FILTERSPEC, list->num);
+    UINT count = 0;
+
+    for (int i = 0; i < list->num; i++) {
+        mpv_node *item = &list->values[i];
+        if (item->format != MPV_FORMAT_NODE_MAP) continue;
+
+        char *name = NULL, *spec = NULL;
+        mpv_node_list *values = item->u.list;
+
+        for (int j = 0; j < values->num; j++) {
+            char *key = values->keys[j];
+            mpv_node *value = &values->values[j];
+            if (value->format != MPV_FORMAT_STRING) continue;
+
+            if (strcmp(key, "name") == 0) name = value->u.string;
+            if (strcmp(key, "spec") == 0) spec = value->u.string;
+        }
+
+        if (name != NULL && spec != NULL) {
+            specs[count].pszName = mp_from_utf8(tmp, name);
+            specs[count].pszSpec = mp_from_utf8(tmp, spec);
+            count++;
+        }
+    }
+
+    if (count > 0) {
+        pfd->lpVtbl->SetFileTypes(pfd, count, specs);
+        pfd->lpVtbl->SetFileTypeIndex(pfd, 1);
+        pfd->lpVtbl->SetDefaultExtension(pfd, specs[0].pszSpec);
+    }
+
+    talloc_free(tmp);
+
+done:
+    mpv_free_node_contents(&node);
+}
+
+// set default path from user property
+static void set_default_path(mpv_handle *mpv, IFileDialog *pfd) {
+    char *path = mpv_get_property_string(mpv, DIALOG_DEF_PATH_PROP);
+    if (path == NULL) return;
+
+    IShellItem *folder;
+    wchar_t *w_path = mp_from_utf8(NULL, path);
+
+    if (SUCCEEDED(SHCreateItemFromParsingName(w_path, NULL, &IID_IShellItem,
+                                              (void **)&folder)))
+        pfd->lpVtbl->SetDefaultFolder(pfd, folder);
+
+    talloc_free(w_path);
+    mpv_free(path);
+}
+
+// set default name used for save dialog
+static void set_default_name(mpv_handle *mpv, IFileDialog *pfd) {
+    char *name = mpv_get_property_string(mpv, DIALOG_DEF_NAME_PROP);
+    if (name == NULL) return;
+
+    wchar_t *w_name = mp_from_utf8(NULL, name);
+    pfd->lpVtbl->SetFileName(pfd, w_name);
+    talloc_free(w_name);
+}
+
+static void add_options(IFileDialog *pfd, DWORD options) {
+    DWORD dwOptions;
+    if (pfd->lpVtbl->GetOptions(pfd, &dwOptions) == S_OK) {
+        pfd->lpVtbl->SetOptions(pfd, dwOptions | options);
+    }
+}
+
+// single file open dialog
+char *open_dialog(void *talloc_ctx, plugin_ctx *ctx) {
+    IFileOpenDialog *pfd = NULL;
+    if (FAILED(CoCreateInstance(&CLSID_FileOpenDialog, NULL,
+                                CLSCTX_INPROC_SERVER, &IID_IFileDialog,
+                                (void **)&pfd)))
+        return NULL;
+
+    add_filters(ctx->mpv, (IFileDialog *)pfd);
+    set_default_path(ctx->mpv, (IFileDialog *)pfd);
+    add_options((IFileDialog *)pfd, FOS_FORCEFILESYSTEM);
+
+    char *path = NULL;
+
+    if (SUCCEEDED(pfd->lpVtbl->Show(pfd, ctx->hwnd))) {
+        IShellItem *psi;
+        if (SUCCEEDED(pfd->lpVtbl->GetResult(pfd, &psi))) {
+            wchar_t *w_path;
+            if (SUCCEEDED(psi->lpVtbl->GetDisplayName(psi, SIGDN_FILESYSPATH,
+                                                      &w_path))) {
+                path = mp_to_utf8(talloc_ctx, w_path);
+                CoTaskMemFree(w_path);
+            }
+            psi->lpVtbl->Release(psi);
+        }
+    }
+
+    pfd->lpVtbl->Release(pfd);
+
+    return path;
+}
+
+// multiple file open dialog
+char **open_dialog_multi(void *talloc_ctx, plugin_ctx *ctx) {
+    IFileOpenDialog *pfd = NULL;
+    if (FAILED(CoCreateInstance(&CLSID_FileOpenDialog, NULL,
+                                CLSCTX_INPROC_SERVER, &IID_IFileOpenDialog,
+                                (void **)&pfd)))
+        return NULL;
+
+    add_filters(ctx->mpv, (IFileDialog *)pfd);
+    set_default_path(ctx->mpv, (IFileDialog *)pfd);
+    add_options((IFileDialog *)pfd, FOS_FORCEFILESYSTEM | FOS_ALLOWMULTISELECT);
+
+    char **paths = NULL;
+
+    if (SUCCEEDED(pfd->lpVtbl->Show(pfd, ctx->hwnd))) {
+        IShellItemArray *psia;
+        if (SUCCEEDED(pfd->lpVtbl->GetResults(pfd, &psia))) {
+            DWORD count;
+            if (SUCCEEDED(psia->lpVtbl->GetCount(psia, &count))) {
+                paths =
+                    talloc_zero_size(talloc_ctx, sizeof(char *) * (count + 1));
+                for (DWORD i = 0; i < count; i++) {
+                    IShellItem *psi;
+                    if (SUCCEEDED(psia->lpVtbl->GetItemAt(psia, i, &psi))) {
+                        wchar_t *w_path;
+                        if (SUCCEEDED(psi->lpVtbl->GetDisplayName(
+                                psi, SIGDN_FILESYSPATH, &w_path))) {
+                            paths[i] = mp_to_utf8(talloc_ctx, w_path);
+                            CoTaskMemFree(w_path);
+                        }
+                        psi->lpVtbl->Release(psi);
+                    }
+                }
+            }
+            psia->lpVtbl->Release(psia);
+        }
+    }
+
+    pfd->lpVtbl->Release(pfd);
+
+    return paths;
+}
+
+// folder open dialog
+char *open_folder(void *talloc_ctx, plugin_ctx *ctx) {
+    IFileOpenDialog *pfd = NULL;
+    if (FAILED(CoCreateInstance(&CLSID_FileOpenDialog, NULL,
+                                CLSCTX_INPROC_SERVER, &IID_IFileOpenDialog,
+                                (void **)&pfd)))
+        return NULL;
+
+    set_default_path(ctx->mpv, (IFileDialog *)pfd);
+    add_options((IFileDialog *)pfd, FOS_FORCEFILESYSTEM | FOS_PICKFOLDERS);
+
+    char *path = NULL;
+
+    if (SUCCEEDED(pfd->lpVtbl->Show(pfd, ctx->hwnd))) {
+        IShellItem *psi;
+        if (SUCCEEDED(pfd->lpVtbl->GetResult(pfd, &psi))) {
+            wchar_t *w_path;
+            if (SUCCEEDED(psi->lpVtbl->GetDisplayName(psi, SIGDN_FILESYSPATH,
+                                                      &w_path))) {
+                path = mp_to_utf8(talloc_ctx, w_path);
+                CoTaskMemFree(w_path);
+            }
+            psi->lpVtbl->Release(psi);
+        }
+    }
+
+    pfd->lpVtbl->Release(pfd);
+
+    return path;
+}
+
+// save dialog
+char *save_dialog(void *talloc_ctx, plugin_ctx *ctx) {
+    IFileSaveDialog *pfd = NULL;
+    if (FAILED(CoCreateInstance(&CLSID_FileSaveDialog, NULL,
+                                CLSCTX_INPROC_SERVER, &IID_IFileSaveDialog,
+                                (void **)&pfd)))
+        return NULL;
+
+    add_filters(ctx->mpv, (IFileDialog *)pfd);
+    set_default_path(ctx->mpv, (IFileDialog *)pfd);
+    set_default_name(ctx->mpv, (IFileDialog *)pfd);
+    add_options((IFileDialog *)pfd, FOS_FORCEFILESYSTEM);
+
+    char *path = NULL;
+
+    if (SUCCEEDED(pfd->lpVtbl->Show(pfd, ctx->hwnd))) {
+        IShellItem *psi;
+        if (SUCCEEDED(pfd->lpVtbl->GetResult(pfd, &psi))) {
+            wchar_t *w_path;
+            if (SUCCEEDED(psi->lpVtbl->GetDisplayName(psi, SIGDN_FILESYSPATH,
+                                                      &w_path))) {
+                path = mp_to_utf8(talloc_ctx, w_path);
+                CoTaskMemFree(w_path);
+            }
+            psi->lpVtbl->Release(psi);
+        }
+    }
+
+    pfd->lpVtbl->Release(pfd);
+
+    return path;
+}

--- a/src/dialog.h
+++ b/src/dialog.h
@@ -1,0 +1,13 @@
+// Copyright (c) 2023 tsl0922. All rights reserved.
+// SPDX-License-Identifier: GPL-2.0-only
+
+#ifndef MPV_PLUGIN_DIALOG_H
+#define MPV_PLUGIN_DIALOG_H
+
+#include "plugin.h"
+
+char *open_dialog(void *talloc_ctx, plugin_ctx *ctx);
+char **open_dialog_multi(void *talloc_ctx, plugin_ctx *ctx);
+char *open_folder(void *talloc_ctx, plugin_ctx *ctx);
+char *save_dialog(void *talloc_ctx, plugin_ctx *ctx);
+#endif

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -4,6 +4,7 @@
 #ifndef MPV_PLUGIN_H
 #define MPV_PLUGIN_H
 
+#include <stdbool.h>
 #include <windows.h>
 #include <mpv/client.h>
 #include "misc/dispatch.h"
@@ -27,6 +28,7 @@ typedef struct {
 } plugin_ctx;
 
 wchar_t *mp_from_utf8(void *talloc_ctx, const char *s);
+char *mp_to_utf8(void *talloc_ctx, const wchar_t *s);
 char *mp_get_prop_string(void *talloc_ctx, const char *prop);
 char *mp_expand_path(void *talloc_ctx, char *path);
 char *mp_read_file(void *talloc_ctx, char *path);


### PR DESCRIPTION
### Messages

- `clipboard/get <src>`: get clipboard text
- `clipboard/set <text>`: set clipboard text
- `dialog/open <src>`: single file open dialog
- `dialog/open-multi <src>`: multiple file open dialog
- `dialog/open-folder <src>`: folder choosing dialog
- `dialog/save <src>`: file save dialog

properties can be set to custom dialog behaviour:

- `user-data/menu/dialog/filters`: custom file type filters, the first one will be default selected
- `user-data/menu/dialog/default-path`: default path for open/save dialog
- `user-data/menu/dialog/default-name`: default file name for save dialog

### Example

**dialog.lua**
```lua
local file_types_prop = 'user-data/menu/dialog/filters'
local file_types = {
    { name = 'All Files (*.*)', spec = '*.*' },
    { name = 'Video Files',     spec = '*.mpeg4;*.m4v;*.mp4;*.mp4v;*.mpg4;*.h264;*.avc;*.x264;*.264;*.hevc;*.h265;*.x265;*.265;*.m2ts;*.m2t;*.mts;*.mtv;*.ts;*.tsv;*.tsa;*.tts;*.mpeg;*.mpg;*.mpe;*.mpeg2;*.m1v;*.m2v;*.mp2v;*.mkv;*.mk3d;*.wm;*.wmv;*.asf;*.vob;*.vro;*.evob;*.evo;*.ogv;*.ogm;*.ogx;*.webm;*.avi;*.vfw;*.divx;*.3iv;*.xvid;*.nut;*.flic;*.fli;*.flc;*.nsv;*.gxf;*.mxf;*.dvr-ms;*.dvr;*.wtv;*.dv;*.hdv;*.flv;*.f4v;*.qt;*.mov;*.hdmov;*.rm;*.rmvb;*.3gpp;*.3gp;*.3gp2;*.3g2;*.yuv;*.y4m' },
    { name = 'Audio Files',     spec = '*.mp3;*.m4a;*.aac;*.flac;*.ac3;*.a52;*.eac3;*.mpa;*.m1a;*.m2a;*.mp1;*.mp2;*.oga;*.ogg;*.wav;*.mlp;*.dts;*.dts-hd;*.dtshd;*.true-hd;*.thd;*.truehd;*.thd+ac3;*.tta;*.pcm;*.aiff;*.aif;*.aifc;*.amr;*.awb;*.au;*.snd;*.lpcm;*.ape;*.wv;*.shn;*.adts;*.adt;*.opus;*.spx;*.mka;*.weba;*.wma;*.f4a;*.ra;*.ram;*.3ga;*.3ga2;*.ay;*.gbs;*.gym;*.hes;*.kss;*.nsf;*.nsfe;*.sap;*.spc;*.vgm;*.vgz;*.m3u;*.m3u8;*.pls;*.cue' },
    { name = 'Image Files',     spec = '*.jpg;*.bmp;*.png;*.gif;*.webp' },
    { name = 'Subtitle Files',  spec = '*.srt;*.ass;*.idx;*.sub;*.sup;*.ttxt;*.txt;*.ssa;*.smi;*.mks' },
    { name = 'Playlist Files',  spec = '*.m3u;*.m3u8;*.pls;*.cue' },
}
mp.set_property_native(file_types_prop, file_types)

local function dialog_open_cb(...)
    for i, v in ipairs({ ... }) do
        local path = tostring(v)
        local option = i > 1 and 'append' or 'replace'
        mp.commandv('loadfile', path, option)
    end
end

mp.register_script_message('dialog-open-reply', dialog_open_cb)
mp.register_script_message('dialog-open-multi-reply', dialog_open_cb)
mp.register_script_message('dialog-open-folder-reply', dialog_open_cb)

mp.register_script_message('open', function()
    mp.commandv('script-message-to', 'menu', 'dialog/open-multi', mp.get_script_name())
end)

mp.register_script_message('open-folder', function()
    mp.commandv('script-message-to', 'menu', 'dialog/open-folder', mp.get_script_name())
end)

mp.register_script_message('clipboard-get-reply', function(clipboard)
    mp.commandv('loadfile', clipboard, 'append-play')
    mp.osd_message('clipboard: ' .. clipboard)
end)

mp.register_script_message('open-clipboard', function()
    mp.commandv('script-message-to', 'menu', 'clipboard/get', mp.get_script_name())
end)
```

**input.conf**

```
Ctrl+o      script-message-to dialog open            #menu: Open > Files...
Ctrl+O      script-message-to dialog open-folder     #menu: Open > Folder...
Ctrl+v      script-message-to dialog open-clipboard  #menu: Open > Clipboard
```