### PR TITLE
No longer uppercase track lang

### DIFF
--- a/src/lua/dyn_menu.lua
+++ b/src/lua/dyn_menu.lua
@@ -245,7 +245,7 @@ local function build_track_items(list, type, prop, prefix)
 
             items[#items + 1] = {
                 title = build_track_title(track, prefix, filename),
-                shortcut = (track.lang and track.lang ~= '') and track.lang:upper() or nil,
+                shortcut = (track.lang and track.lang ~= '') and track.lang or nil,
                 cmd = string.format('set %s %d', prop, track.id),
                 state = state,
             }


### PR DESCRIPTION
MPV upstream commit https://github.com/mpv-player/mpv/commit/ab3b1744b9a6c7cc33e16538e175af2b00d3c2e3 has introduced support for BCP 47 language tags, and now track lang has uppercase and lowercase content.

look like
![image](https://github.com/tsl0922/mpv-menu-plugin/assets/61936050/958a184f-d0ed-49f5-8355-486f5cb5052f)
