### PR TITLE
update uosc menu syntax to ignore comments

### DIFF
--- a/src/lua/dyn_menu.lua
+++ b/src/lua/dyn_menu.lua
@@ -559,6 +559,7 @@ local function parse_input_conf(conf)
         local c = line:match('^%s*#')
         if c and (not o.uosc_syntax) then return end
         local key, cmd = line:match('%s*([%S]+)%s+(.-)%s*$')
+        if key and key:match('^#%S+') then return end
         return ((o.uosc_syntax and c) and '' or key), cmd
     end
 


### PR DESCRIPTION
Sync uosc upstream feature fixes: https://github.com/tomasklaen/uosc/commit/d4b1343609434a61e45da7d654f69eea6a0dc17c
See-Also: https://github.com/tsl0922/mpv-menu-plugin/issues/8