### PR TITLE
write watch later file before set playlist index

### DIFF
--- a/src/lua/dyn_menu.lua
+++ b/src/lua/dyn_menu.lua
@@ -399,6 +399,8 @@ local function update_playlist_menu(menu)
         })
     end
 
+    local write_watch_later_cmd = mp.get_property_bool('save-position-on-quit', false) 
+                                    and 'write-watch-later-config;' or ''
     for id = from, to do
         local item = playlist[id]
         if item then
@@ -406,7 +408,7 @@ local function update_playlist_menu(menu)
             append_menu(submenu, {
                 title = build_playlist_title(item, id - 1),
                 shortcut = (ext and ext ~= '') and ext:upper() or nil,
-                cmd = string.format('playlist-play-index %d', id - 1),
+                cmd = string.format('%s playlist-play-index %d', write_watch_later_cmd, id - 1),
                 state = (item.playing or item.current) and { 'checked' } or {},
             })
         end


### PR DESCRIPTION
这样在播放列表中随意切换可以记住每个文件的播放位置，比从头开始播放体验更好，\
与 [jonniek/mpv-playlistmanager](https://github.com/jonniek/mpv-playlistmanager) 的行为保持一致。

我在input.conf中绑定`playlist-prev`和`playlist-next`的时候也习惯加上`write-watch-later-config`，用起来更舒服。