### PR TITLE
Fix the issue of menu click failure caused by excessive menu updates

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -14,6 +14,8 @@ static int append_menu(HMENU hmenu, UINT fMask, UINT fType, UINT fState,
     mii.cbSize = sizeof(mii);
     mii.fMask = MIIM_ID | fMask;
     mii.wID = id++;
+    // menu identifier should never be greater than the max value of unsigned 16-bit integer
+    if (id > 0xFFFF) id = WM_USER + 100;
 
     if (fMask & MIIM_FTYPE) mii.fType = fType;
     if (fMask & MIIM_STATE) mii.fState = fState;
@@ -141,7 +143,7 @@ static void build_menu(void *talloc_ctx, HMENU hmenu, mpv_node *node) {
 // update HMENU if menu node changed
 void update_menu(plugin_ctx *ctx, mpv_node *node) {
     while (GetMenuItemCount(ctx->hmenu) > 0)
-        RemoveMenu(ctx->hmenu, 0, MF_BYPOSITION);
+        DeleteMenu(ctx->hmenu, 0, MF_BYPOSITION);
     talloc_free_children(ctx->hmenu_ctx);
     build_menu(ctx->hmenu_ctx, ctx->hmenu, node);
 }

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -27,6 +27,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
             if (GetCursorPos(&pt)) show_menu(ctx, &pt);
             break;
         case WM_COMMAND:
+            // low-word of wParam represents the menu identifier, is an unsigned 16-bit integer
             handle_menu(ctx, LOWORD(wParam));
             break;
         default:


### PR DESCRIPTION
1. make the menu identifier never greater than 0xFFFF due to the WM_COMMAND message only provides an unsigned 16-bit integer menu identifier. 
ref: 
https://learn.microsoft.com/en-us/windows/win32/menurc/wm-command

2. old menu items are never reused, should delete by DeleteMenu() instead of RemoveMenu(), DeleteMenu() destroys the handle to the menu or submenu and frees the memory.
ref: 
https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-deletemenu
https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-removemenu

Closes #64