### PR TITLE
Fixed bug where dyn-menu would not immediately load in when force-win…

### DIFF
--- a/src/lua/dyn_menu.lua
+++ b/src/lua/dyn_menu.lua
@@ -247,7 +247,7 @@ local function build_track_items(list, type, prop, prefix)
             if track.selected and track.id == pos then
                 state[#state + 1] = 'checked'
                 if type == 'sub' then
-                    if (prop == 'sid' and not get('sub-visibility')) or 
+                    if (prop == 'sid' and not get('sub-visibility')) or
                         (prop == 'secondary-sid' and not get('secondary-sub-visibility'))
                     then
                         state[#state + 1] = 'disabled'


### PR DESCRIPTION
Noticed on my MPV instance that the dyn_menu would often not load in until toggling full screen on/off, pausing/playing, just a few actions and it would load in properly. This fix loads it in properly every time. Also, dialog.lua and menu.dll no longer seem to serve any purpose, but I'll leave the pruning of dead weight to you.